### PR TITLE
Configure Pages CMS for ComuniDados

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -1,0 +1,263 @@
+# Pages CMS configuration for the ComuniDados Jekyll site.
+# The paths and front matter names intentionally match the existing files.
+
+media:
+  - name: images
+    label: Imagens
+    input: assets/images
+    output: /assets/images
+    categories: [image]
+    extensions: [png, jpg, jpeg, gif, webp, svg]
+    rename: safe
+
+content:
+  - name: articles
+    label: Artigos
+    type: collection
+    path: _posts
+    format: yaml-frontmatter
+    filename: "{year}-{month}-{day}-{title}.md"
+    subfolders: false
+    operations:
+      delete: false
+    view:
+      primary: title
+      fields: [title, date, category, read_time]
+      sort: [date, title]
+      search: [title, description, category]
+      default:
+        sort: date
+        order: desc
+    fields:
+      - name: layout
+        label: false
+        type: string
+        default: post
+        hidden: true
+      - name: title
+        label: Título
+        type: string
+        required: true
+        options:
+          maxlength: 140
+      - name: description
+        label: Descrição
+        type: text
+        required: true
+        options:
+          maxlength: 280
+      - name: date
+        label: Data de publicação
+        type: date
+        required: true
+        options:
+          time: true
+          format: "yyyy-MM-dd HH:mm:ss xx"
+      - name: category
+        label: Categoria
+        type: string
+        required: true
+        options:
+          maxlength: 60
+      - name: read_time
+        label: Tempo de leitura
+        type: string
+        required: true
+        pattern: "^[0-9]+ min$"
+        description: "Use o formato: 8 min"
+      - name: body
+        label: Conteúdo
+        type: rich-text
+        required: true
+        options:
+          format: markdown
+          switcher: true
+          media: images
+          path: articles
+          rename: safe
+
+  - name: institutional
+    label: Páginas institucionais
+    type: group
+    items:
+      - name: about
+        label: Sobre
+        type: file
+        path: about.md
+        format: yaml-frontmatter
+        fields:
+          - name: layout
+            label: false
+            type: string
+            default: page
+            hidden: true
+          - name: title
+            label: Título
+            type: string
+            required: true
+          - name: description
+            label: Descrição
+            type: text
+            required: true
+          - name: permalink
+            label: Caminho público
+            type: string
+            required: true
+            readonly: true
+          - name: body
+            label: Conteúdo
+            type: rich-text
+            required: true
+            options:
+              format: markdown
+              switcher: true
+              media: images
+              path: institutional
+              rename: safe
+      - name: manifesto
+        label: Manifesto
+        type: file
+        path: manifesto.md
+        format: yaml-frontmatter
+        fields:
+          - name: layout
+            label: false
+            type: string
+            default: page
+            hidden: true
+          - name: title
+            label: Título
+            type: string
+            required: true
+          - name: description
+            label: Descrição
+            type: text
+            required: true
+          - name: permalink
+            label: Caminho público
+            type: string
+            required: true
+            readonly: true
+          - name: body
+            label: Conteúdo
+            type: rich-text
+            required: true
+            options:
+              format: markdown
+              switcher: true
+              media: images
+              path: institutional
+              rename: safe
+      - name: dossiers
+        label: Dossiês
+        type: file
+        path: dossies.md
+        format: yaml-frontmatter
+        fields:
+          - name: layout
+            label: false
+            type: string
+            default: page
+            hidden: true
+          - name: title
+            label: Título
+            type: string
+            required: true
+          - name: description
+            label: Descrição
+            type: text
+            required: true
+          - name: permalink
+            label: Caminho público
+            type: string
+            required: true
+            readonly: true
+          - name: body
+            label: Conteúdo
+            type: rich-text
+            required: true
+            options:
+              format: markdown
+              switcher: true
+              media: images
+              path: institutional
+              rename: safe
+      - name: investigations
+        label: Investigações
+        type: file
+        path: investigacoes.md
+        format: yaml-frontmatter
+        fields:
+          - name: layout
+            label: false
+            type: string
+            default: page
+            hidden: true
+          - name: title
+            label: Título
+            type: string
+            required: true
+          - name: description
+            label: Descrição
+            type: text
+            required: true
+          - name: permalink
+            label: Caminho público
+            type: string
+            required: true
+            readonly: true
+          - name: body
+            label: Conteúdo
+            type: rich-text
+            required: true
+            options:
+              format: markdown
+              switcher: true
+              media: images
+              path: institutional
+              rename: safe
+      - name: curriculum
+        label: Currículo
+        type: file
+        path: curriculo.md
+        format: yaml-frontmatter
+        fields:
+          - name: layout
+            label: false
+            type: string
+            default: page
+            hidden: true
+          - name: title
+            label: Título
+            type: string
+            required: true
+          - name: description
+            label: Descrição
+            type: text
+            required: true
+          - name: permalink
+            label: Caminho público
+            type: string
+            required: true
+            readonly: true
+          - name: body
+            label: Conteúdo
+            type: rich-text
+            required: true
+            options:
+              format: markdown
+              switcher: true
+              media: images
+              path: institutional
+              rename: safe
+
+settings:
+  content:
+    merge: true
+  commit:
+    identity: user
+    templates:
+      create: "content: create {path}"
+      update: "content: update {path}"
+      delete: "content: delete {path}"
+      rename: "content: rename {oldPath} -> {newPath}"

--- a/README.md
+++ b/README.md
@@ -62,3 +62,23 @@ Antes da publicação:
 4. habilite os links de visualização e download somente depois da revisão.
 
 Não mantenha PDFs provisórios com extensão falsa nem cópias adicionais do currículo.
+
+## Editar com Pages CMS
+
+O repositório possui um `.pages.yml` na raiz. Ele configura o [Pages CMS](https://pagescms.org/) para editar artigos em `_posts`, páginas institucionais existentes e imagens em `assets/images`, preservando os nomes de front matter usados pelo Jekyll.
+
+Para acessar:
+
+1. abra [app.pagescms.org](https://app.pagescms.org/);
+2. entre com GitHub e autorize o Pages CMS no repositório `betinaschilling/betinaschilling.github.io`;
+3. selecione a branch que deseja editar — a configuração é lida por repositório e branch;
+4. abra **Artigos** ou **Páginas institucionais**;
+5. salve as alterações em uma branch de trabalho e revise a PR antes do merge.
+
+Novos artigos recebem o formato de nome `AAAA-MM-DD-titulo.md`, usam `layout: post` e mantêm o conteúdo em Markdown. Imagens inseridas no rich text são salvas em `assets/images` e referenciadas como `/assets/images/...`, compatível com o Jekyll. O preview local consistente com os caminhos publicados é:
+
+```bash
+bundle exec jekyll serve
+```
+
+Depois, abra `http://localhost:4000/` ou a URL do post em `/categoria/AAAA/MM/DD/titulo/`, conforme o comportamento atual de `permalink: pretty` em `_config.yml` — por exemplo, `/método/2026/07/27/forecast-101-prever-nao-e-adivinhar/`. O Pages CMS não publica conteúdo por conta própria: ele grava alterações no GitHub; o build do GitHub Pages continua sendo a etapa de publicação.


### PR DESCRIPTION
## O que mudou

- adiciona `.pages.yml` na raiz com configuração Pages CMS compatível com o Jekyll atual;
- configura Artigos em `_posts` com título, descrição, data, categoria, tempo de leitura e conteúdo Markdown rich text;
- configura upload e referência de imagens em `assets/images`;
- configura as páginas institucionais existentes: Sobre, Manifesto, Dossiês, Investigações e Currículo;
- documenta acesso, uso, criação de artigos, imagens e preview local no README.

A branch é baseada na entrega anterior do Forecast 101, que permanece preservada no histórico e acompanha esta PR.

## Compatibilidade

- posts usam `yaml-frontmatter` e o campo especial `body`;
- novos nomes seguem `YYYY-MM-DD-{title}.md`;
- `layout: post` é preenchido como campo oculto;
- páginas institucionais preservam seus `permalink`;
- `settings.content.merge: true` reduz o risco de perder chaves existentes;
- exclusão de artigos está desabilitada;
- URLs de preview seguem o Jekyll existente, incluindo a categoria no caminho quando aplicável.

## Validações

- YAML parseado com PyYAML;
- esquema conferido contra os campos e caminhos atuais;
- artigo temporário criado e validado, depois removido;
- imagem SVG temporária adicionada e referenciada, depois removida;
- build Jekyll executado em container Ruby 3.2 com `bundle exec jekyll build`;
- home, índice de artigos, post categorizado, página institucional, imagem e CSS gerados conferidos;
- `git diff --check`;
- nenhum conteúdo fictício ou arquivo de teste permanece.