### PR TITLE
Simplificar apresentação da página de currículo

### DIFF
--- a/assets/css/editorial.scss
+++ b/assets/css/editorial.scss
@@ -68,12 +68,14 @@
 .document-cover h2{max-width:700px;margin:22px 0;font:500 clamp(42px,5vw,70px)/.98 Georgia;letter-spacing:-.04em}
 .document-cover>p:not(.eyebrow,.document-note){max-width:690px;font:18px/1.6 Georgia;color:var(--grey)}
 .document-stamp{display:inline-block;float:right;padding:9px 12px;border:1px solid var(--red);color:var(--red);font:700 10px monospace;letter-spacing:.09em}
-.document-meta{display:grid;grid-template-columns:repeat(4,1fr);margin:45px 0 30px;border-top:1px solid var(--line);border-bottom:1px solid var(--line)}
+.document-meta{display:grid;grid-template-columns:repeat(3,1fr);margin:45px 0 30px;border-top:1px solid var(--line);border-bottom:1px solid var(--line)}
 .document-meta div{padding:18px 20px;border-right:1px solid var(--line)}
 .document-meta div:last-child{border-right:0}
 .document-meta dt{font:700 9px monospace;letter-spacing:.1em;text-transform:uppercase;color:var(--grey)}
 .document-meta dd{margin:7px 0 0;font:16px Georgia}
 .document-note{font:12px/1.6 monospace;color:var(--grey)}
+.document-followup{max-width:690px;margin:0 auto 70px;font:18px/1.6 Georgia;color:var(--grey)}
+.document-followup a{color:var(--red);border-bottom:1px solid var(--red)}
 a:focus-visible,button:focus-visible{outline:3px solid var(--red);outline-offset:4px}
 .manifesto-teaser a:focus-visible,.site-footer a:focus-visible{outline-color:var(--yellow)}
 
@@ -89,4 +91,5 @@ a:focus-visible,button:focus-visible{outline:3px solid var(--red);outline-offset
   .document-meta{grid-template-columns:1fr 1fr}
   .document-meta div:nth-child(2){border-right:0}
   .document-meta div:nth-child(-n+2){border-bottom:1px solid var(--line)}
+  .document-followup{font-size:17px;margin-bottom:50px}
 }

--- a/curriculo.md
+++ b/curriculo.md
@@ -1,29 +1,30 @@
 ---
 layout: page
 title: "Currículo"
-description: "Documento profissional de Cheila Betina Schilling dos Santos."
+description: "Resumo profissional e versões do currículo de Cheila Betina Schilling dos Santos."
 permalink: /curriculo/
 ---
 
 <section class="document-cover">
-  <div class="document-stamp">PDF / DISPONÍVEL</div>
-  <p class="eyebrow">Documento profissional —</p>
-  <h2>Três versões, uma trajetória híbrida.</h2>
-  <p>Currículo de Cheila Betina Schilling dos Santos, com experiência em engenharia de dados, ciência de dados, analytics e produtos analíticos.</p>
+  <p class="eyebrow">Apresentação profissional —</p>
+  <h2>Engenharia de dados, ciência de dados e analytics para decisões melhores.</h2>
+  <p>Profissional de dados com atuação híbrida entre engenharia de dados, ciência de dados, analytics, advanced analytics e produtos de dados. Trabalho da definição do problema à sustentação da solução em produção, conectando dados, modelagem, decisão e operação.</p>
 
   <dl class="document-meta">
-    <div><dt>Documento</dt><dd>Currículo profissional</dd></div>
+    <div><dt>Atuação</dt><dd>Dados · Modelagem · Produtos</dd></div>
     <div><dt>Idiomas</dt><dd>Português · Inglês · Espanhol</dd></div>
-    <div><dt>Formato</dt><dd>PDF</dd></div>
-    <div><dt>Status</dt><dd>Atualizado</dd></div>
+    <div><dt>Formato</dt><dd>PDF · 3 páginas</dd></div>
   </dl>
 
-  <p class="document-note">Selecione a versão desejada:</p>
-  <p>
-    <a class="button" href="{{ '/assets/documents/curriculo-cheila-betina-schilling.pdf' | relative_url }}">Português →</a>
-    <a class="button dark" href="{{ '/assets/documents/curriculo-cheila-betina-schilling-en.pdf' | relative_url }}">English →</a>
-    <a class="button dark" href="{{ '/assets/documents/curriculo-cheila-betina-schilling-es.pdf' | relative_url }}">Español →</a>
+  <p class="document-note">Escolha a versão adequada ao contexto da sua conversa:</p>
+  <p class="document-links">
+    <a class="button" href="{{ '/assets/documents/curriculo-cheila-betina-schilling.pdf' | relative_url }}">Currículo em português →</a>
+    <a class="button dark" href="{{ '/assets/documents/curriculo-cheila-betina-schilling-en.pdf' | relative_url }}">Resume in English →</a>
+    <a class="button dark" href="{{ '/assets/documents/curriculo-cheila-betina-schilling-es.pdf' | relative_url }}">Currículum en español →</a>
   </p>
 </section>
 
-<p>Minha apresentação e meus projetos técnicos também estão disponíveis no <a href="{{ '/sobre/' | relative_url }}">Sobre</a>, no <a href="https://github.com/betinaschilling" rel="me noopener noreferrer">GitHub</a> e no <a href="https://betinaschilling.github.io/">portfólio</a>.</p>
+<section class="document-followup" aria-label="Outros espaços profissionais">
+  <p>O currículo detalha experiências profissionais, formação, competências técnicas e idiomas.</p>
+  <p>Para conhecer os projetos e as decisões metodológicas, visite o <a href="https://github.com/betinaschilling" rel="me noopener noreferrer">GitHub</a>, o <a href="https://betinaschilling.github.io/">portfólio</a>, o <a href="https://www.linkedin.com/in/cheila-betina-santos/" rel="me noopener noreferrer">LinkedIn</a> e o <a href="{{ '/sobre/' | relative_url }}">Sobre</a>.</p>
+</section>


### PR DESCRIPTION
## Resumo

Reorganiza a página `/curriculo/` como uma capa-resumo profissional, mantendo o detalhamento nos PDFs oficiais.

Alterações:

- posicionamento profissional mais direto;
- resumo da atuação híbrida;
- metadados reduzidos a atuação, idiomas e formato;
- downloads em português, inglês e espanhol;
- links para GitHub, portfólio, LinkedIn e Sobre;
- ajuste responsivo do grid de metadados;
- estilo para o bloco final de referências.

A página não duplica a experiência, formação ou lista de tecnologias dos currículos em PDF.

## Validação

- build do Jekyll executado com sucesso;
- links dos três PDFs confirmados;
- CSS compilado pelo build;
- `git diff --check` aprovado;
- nenhuma alteração feita diretamente na master.