### PR TITLE
Render Forecast 101 formulas with MathJax

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,4 +5,19 @@
   {% seo %}
   <link rel="icon" href="{{ '/assets/icons/favicon.ico' | relative_url }}">
   <link rel="stylesheet" href="{{ '/assets/css/editorial.css' | relative_url }}">
+  <script>
+    window.MathJax = {
+      tex: {
+        inlineMath: [['\\(', '\\)']],
+        displayMath: [['\\[', '\\]']],
+        processEscapes: true,
+        tags: 'ams'
+      },
+      svg: {
+        fontCache: 'global',
+        displayAlign: 'center'
+      }
+    };
+  </script>
+  <script defer src="https://cdn.jsdelivr.net/npm/mathjax@4/tex-svg.js"></script>
 </head>

--- a/assets/css/editorial.scss
+++ b/assets/css/editorial.scss
@@ -111,3 +111,5 @@ a:focus-visible,button:focus-visible{outline:3px solid var(--red);outline-offset
 .lab-status{display:flex;justify-content:space-between;gap:20px;padding:14px 0;border-top:1px solid var(--line);border-bottom:1px solid var(--line);font:700 10px/1.4 monospace;letter-spacing:.1em;color:var(--red)}
 .post-laboratory{max-width:850px;margin:20px auto 55px;padding:28px 32px;border-left:4px solid var(--red);background:#e8dfca}
 .post-laboratory p{margin:6px 0;font:17px/1.5 Georgia;color:var(--grey)}
+mjx-container[jax="SVG"][display="true"]{max-width:100%;margin:38px 0!important;padding:18px 0;overflow-x:auto;overflow-y:hidden}
+mjx-container[jax="SVG"] svg{min-width:0}


### PR DESCRIPTION
## O que mudou

- adiciona MathJax 4 ao layout global;
- renderiza LaTeX inline com `\\(...\\)`;
- renderiza fórmulas em bloco com `\\[...\\]`;
- usa saída SVG com cache global de fontes;
- permite rolagem horizontal de expressões largas em telas pequenas.

## Por quê

O Forecast 101 utiliza notação matemática que, sem um renderizador, pode aparecer como texto LaTeX. A mudança apresenta as expressões como fórmulas tipográficas, sem convertê-las em imagens estáticas.

## Validação

- 10 blocos matemáticos com delimitadores balanceados;
- 9 expressões inline com delimitadores balanceados;
- SCSS compilado;
- diff sem erros de whitespace.