### PR TITLE
Publica Forecast 201 sobre validação temporal

### DIFF
--- a/_posts/2026-07-28-forecast-201-validacao-temporal.md
+++ b/_posts/2026-07-28-forecast-201-validacao-temporal.md
@@ -1,0 +1,519 @@
+---
+layout: post
+title: "Forecast 201: como a validação temporal altera a conclusão"
+description: "Janelas expansivas e deslizantes, gaps, sobreposição, refit, validação aninhada e teste final em um experimento controlado."
+date: 2026-07-28 12:00:00 -0300
+category: Método
+read_time: 27 min
+series: Forecast 201
+featured_order: 3
+laboratory: /laboratorio/forecast-201/
+---
+
+Uma estimativa de desempenho não depende apenas do modelo e dos dados. Ela
+depende também das datas escolhidas para treinamento e teste, da distância
+entre esses períodos, da frequência com que o modelo é reajustado e do número
+de vezes em que uma mesma observação participa da avaliação. Em séries
+temporais, essas escolhas descrevem uma situação de uso. Alterá-las pode mudar
+o erro estimado e o modelo que ocupa a primeira posição.
+
+Este artigo investiga esse problema em um experimento controlado. A série, os
+modelos, o horizonte e as métricas permanecem constantes, enquanto uma dimensão
+do protocolo é modificada por vez. São comparadas janelas expansiva e
+deslizantes, gaps de 0, 7 e 14 dias, folds com diferentes graus de sobreposição
+e cadências distintas de *refit* da regressão. A seleção do tamanho da janela
+desse modelo é então executada em uma validação temporal aninhada, antes da
+consulta a um teste final de 168 dias mantido bloqueado durante o
+desenvolvimento.
+
+A pergunta central é:
+
+> Mantidos os dados, os modelos, o horizonte e as métricas, em que medida o
+> desenho de avaliação temporal altera a estimativa de desempenho e o ranking
+> dos modelos?
+
+No experimento, as diferenças foram suficientes para alterar o ranking. A
+regressão de calendário registrou
+WAPE de **8,89%** sob janela expansiva e de **4,63%** sob janela deslizante de
+365 dias. O seasonal naive apresentou o menor valor no primeiro protocolo; a
+regressão, no segundo. Quando o *refit* da regressão passou a ocorrer a cada
+duas ou quatro origens, a média sazonal assumiu a primeira posição. No teste final
+bloqueado, a regressão com janela selecionada pela validação aninhada apresentou
+o menor WAPE observado, **5,23%**, contra **5,77%** do seasonal naive. A
+conclusão descritiva sobre o modelo dependeu do protocolo porque cada
+configuração representava uma condição operacional diferente.
+
+## 1. O objeto estimado pela validação
+
+Considere uma origem \(T_k\), um horizonte \(H\), um gap \(g\) e uma janela de
+treinamento de tamanho \(W_k\). O conjunto usado para ajustar o modelo no fold
+\(k\) pode ser escrito como:
+
+\[
+\mathcal{D}^{(k)}_{\text{train}}
+=
+\{y_t:t\in[T_k-W_k,T_k-1]\}
+\]
+
+O período de teste começa depois do gap:
+
+\[
+\mathcal{D}^{(k)}_{\text{test}}
+=
+\{y_t:t\in[T_k+g,T_k+g+H-1]\}
+\]
+
+O risco estimado pelo backtest é uma agregação das perdas observadas nas
+origens:
+
+\[
+\widehat{R}_{P}(f)
+=
+\frac{1}{K}
+\sum_{k=1}^{K}
+\frac{1}{H}
+\sum_{h=0}^{H-1}
+L\!\left(y_{T_k+g+h},\hat y_{T_k+g+h\mid T_k}\right)
+\]
+
+O subscrito \(P\) explicita algo frequentemente omitido: o risco é condicionado
+ao protocolo \(P\). Esse protocolo inclui a regra de formação das janelas, o
+gap, o espaçamento entre origens, a política de atualização, o processo de
+seleção e a função de perda. Portanto, dois valores de WAPE obtidos sobre a
+mesma série podem estimar desempenhos sob situações de uso diferentes, como
+mostra a literatura sobre avaliação fora da amostra e estimação de desempenho
+temporal ([Tashman, 2000](https://doi.org/10.1016/S0169-2070(00)00065-0);
+[Cerqueira, Torgo e Mozetič, 2020](https://doi.org/10.1007/s10994-020-05910-7)).
+
+Uma janela expansiva responde como o modelo se comportaria se todo o histórico
+fosse preservado. Uma janela deslizante representa uma política que descarta
+dados antigos. Um gap de 14 dias avalia uma previsão feita com duas semanas de
+antecedência. Um protocolo com *refit* a cada quatro origens não estima o mesmo
+sistema que outro reajustado em toda origem. A comparação só é operacionalmente
+útil quando a política simulada é compatível com a política que será executada.
+
+Essa formulação também esclarece o papel do teste final. O backtest de
+desenvolvimento é usado para comparar especificações e escolher o protocolo. No
+experimento, os três candidatos e suas regras são congelados antes do teste
+final, que fornece uma comparação externa entre eles. Quando o mesmo período é
+usado para selecionar configurações e estimar seu desempenho, a estimativa tende
+a incorporar o otimismo da busca
+([Varma e Simon, 2006](https://doi.org/10.1186/1471-2105-7-91)).
+
+## 2. Série, modelos e controle experimental
+
+O laboratório utiliza 1.460 observações diárias sintéticas, geradas com semente
+201. O processo contém tendência, sazonalidade semanal, ciclo anual, eventos
+pontuais e duas mudanças de regime. Os eventos e os regimes não são fornecidos
+explicitamente aos modelos. Essa omissão produz um ambiente no qual a relevância
+do histórico varia ao longo do tempo.
+
+Os primeiros 1.292 dias formam o conjunto de desenvolvimento. Os 168 dias
+restantes, equivalentes a seis horizontes não sobrepostos de 28 dias, compõem o
+teste final. Nenhuma escolha de janela, gap, passo ou modelo utiliza esse bloco.
+
+Três previsores são comparados:
+
+1. **seasonal naive**, que repete recursivamente a última semana disponível;
+2. **média sazonal**, que estima uma média por dia da semana dentro da janela;
+3. **regressão de calendário**, com tendência linear, indicadores de dia da
+   semana e termos harmônicos anuais.
+
+A simplicidade é intencional. O objetivo não é demonstrar superioridade de uma
+arquitetura, mas identificar o efeito isolado do protocolo. Modelos complexos
+adicionariam hiperparâmetros, estocasticidade e custo de ajuste que dificultariam
+a atribuição das diferenças.
+
+O horizonte permanece fixado em 28 dias. O erro é definido como previsão menos
+observado. O WAPE de cada fold é:
+
+\[
+\operatorname{WAPE}_k
+=
+100
+\frac{\sum_{h=0}^{H-1}|y_{T_k+g+h}-\hat y_{T_k+g+h\mid T_k}|}
+{\sum_{h=0}^{H-1}|y_{T_k+g+h}|}
+\]
+
+Também são registrados MAE e viés. O ranking principal usa a média dos WAPEs
+calculados separadamente em cada fold, não um WAPE global sobre todas as
+observações. Essa convenção atribui o mesmo peso às origens e não deve ser
+interpretada como se cada fold fornecesse evidência independente, sobretudo nos
+protocolos com sobreposição.
+
+## 3. Janela expansiva e memória do processo
+
+Na janela expansiva, o início do treinamento permanece fixo e o fim avança com
+a origem:
+
+\[
+\mathcal{D}^{(k)}_{\text{train}}
+=
+\{y_0,\ldots,y_{T_k-1}\}
+\]
+
+O procedimento aumenta a amostra a cada fold. Se os parâmetros do processo
+forem aproximadamente estáveis, essa acumulação tende a reduzir a variância da
+estimação e permite representar ciclos longos. Se o processo muda, entretanto,
+observações antigas podem introduzir viés ao descrever relações que deixaram de
+vigorar.
+
+Na janela deslizante, apenas as \(W\) observações imediatamente anteriores à
+origem são preservadas:
+
+\[
+\mathcal{D}^{(k)}_{\text{train}}
+=
+\{y_{T_k-W},\ldots,y_{T_k-1}\}
+\]
+
+O tamanho \(W\) estabelece um compromisso entre memória e adaptação. Uma janela
+longa oferece mais observações e maior cobertura sazonal, mas reage lentamente.
+Uma janela curta reduz a influência de regimes anteriores, ao custo de aumentar
+a variância e possivelmente eliminar ciclos necessários à identificação do
+modelo.
+
+Os resultados mostram esse compromisso:
+
+| Protocolo | Seasonal naive | Média sazonal | Regressão |
+|---|---:|---:|---:|
+| Expansiva | **5,34%** | 8,49% | 8,89% |
+| Deslizante, 365 dias | 5,34% | 5,30% | **4,63%** |
+| Deslizante, 180 dias | **5,34%** | 6,56% | 5,36% |
+
+A regressão de calendário apresentou o maior WAPE entre os três métodos na
+janela expansiva.
+A janela de 365 dias reduziu seu WAPE em 4,26 pontos percentuais e alterou a
+primeira posição. Como o processo gerador contém mudanças de nível e inclinação, a
+regressão expansiva é estimada sobre observações produzidas antes e depois das
+mudanças simuladas. A janela de 365 dias reduz a presença dos regimes antigos;
+o experimento não isola esse mecanismo como causa do ganho.
+
+Reduzir a janela para 180 dias não produziu ganho adicional. A regressão passou
+a estimar os termos harmônicos anuais com cobertura parcial do ciclo e registrou
+WAPE de 5,36%, próximo aos 5,34% do seasonal naive. O experimento não sustenta a
+regra “dados recentes são melhores”. Ele mostra que a quantidade adequada de
+memória depende simultaneamente da mudança de regime e da estrutura que o
+modelo precisa identificar.
+
+O seasonal naive apresenta exatamente o mesmo WAPE nos três protocolos porque
+usa somente a última semana. Alterar o início da janela não muda sua informação.
+Essa invariância funciona como controle: as diferenças observadas nos outros
+modelos decorrem da forma como eles utilizam o histórico, não de uma mudança nas
+datas de teste.
+
+## 4. Gap: antecedência, latência e embargo
+
+O gap desloca em \(g\) dias o início do período avaliado.
+No laboratório, são testados \(g=0\), \(g=7\) e \(g=14\), mantendo a janela de
+365 dias e origens não sobrepostas.
+
+| Gap | Seasonal naive | Média sazonal | Regressão |
+|---|---:|---:|---:|
+| 0 dias | 5,34% | 5,30% | **4,63%** |
+| 7 dias | 5,65% | 5,36% | **4,91%** |
+| 14 dias | 5,86% | 5,43% | **5,31%** |
+
+O aumento do gap tornou a tarefa progressivamente mais difícil para os três
+métodos. Na regressão, o WAPE passou de 4,63% para 5,31%. O modelo permaneceu
+com o menor valor, mas sua vantagem sobre a média sazonal caiu de 0,67 para
+0,12 ponto percentual. Sem uma margem de equivalência ou análise de incerteza,
+essa diferença não sustenta uma conclusão operacional categórica.
+
+Neste artigo, gap e embargo designam mecanismos diferentes. Um gap operacional
+representa o tempo entre o
+fechamento da informação e o início do uso da previsão: atraso de ingestão,
+processamento, negociação, fabricação ou preparação da decisão. Um embargo
+estatístico procura reduzir contaminação quando exemplos próximos compartilham
+informações ou rótulos. Os mecanismos podem produzir a mesma geometria na
+partição, mas justificam tamanhos diferentes.
+
+Se uma área precisa aprovar um plano duas semanas antes da execução, avaliar
+com \(g=0\) responde à pergunta errada, mesmo na ausência de leakage. O modelo
+estaria recebendo quatorze dias de informação que a operação não terá. Nesse
+caso, o gap não é uma precaução opcional; ele faz parte do horizonte efetivo da
+decisão.
+
+## 5. Folds sobrepostos e dependência
+
+Com horizonte de 28 dias e passo de 28, os períodos de teste não se sobrepõem.
+Com passo de 14, cada fold compartilha metade do período com o fold seguinte.
+Com passo de 7, a sobreposição chega a 75%.
+
+O aumento da frequência de origens oferece duas vantagens. Ele avalia o modelo
+em mais estados do processo e aproxima uma operação que publica previsões
+semanalmente. No entanto, as novas medições não equivalem ao mesmo número de
+replicações independentes. Uma data difícil pode afetar quatro folds quando o
+passo é de sete dias, e os erros de horizontes diferentes passam a compartilhar
+o mesmo valor observado.
+
+No experimento:
+
+| Passo entre origens | Sobreposição | Seasonal naive | Média sazonal | Regressão |
+|---|---:|---:|---:|---:|
+| 28 dias | 0% | 5,34% | 5,30% | **4,63%** |
+| 14 dias | 50% | 6,05% | 6,93% | **5,40%** |
+| 7 dias | 75% | 5,51% | 7,40% | **4,89%** |
+
+O menor WAPE permaneceu com a regressão, mas a magnitude não foi monotônica.
+Alterar o passo também altera as origens amostradas. Os resultados mostram que
+as amostras de folds tiveram dificuldades distintas, mas o experimento não
+identifica quais características de cada origem produziram essa diferença.
+
+Não se deve concluir que a sobreposição causou aumento ou redução do erro. Ela
+modificou a amostra de situações avaliadas e a dependência entre as perdas. A
+inferência sobre diferenças entre modelos precisa considerar essa dependência,
+por exemplo por reamostragem em blocos, comparação agregada por origem ou
+modelos para a série de diferenciais de perda. Aplicar diretamente um erro
+padrão baseado em observações independentes pode subestimar a incerteza. A
+validade de procedimentos de validação cruzada em séries temporais depende das
+propriedades do processo e dos erros
+([Bergmeir, Hyndman e Koo, 2018](https://doi.org/10.1016/j.csda.2017.11.003)).
+
+Uma decisão prática precede a técnica estatística: o backtest deve simular a
+cadência real de emissão. Se previsões são publicadas semanalmente para 28 dias,
+folds sobrepostos são parte do sistema. A resposta não é removê-los apenas para
+facilitar a inferência, mas representar sua dependência corretamente.
+
+<figure class="article-figure">
+  <img src="{{ '/assets/images/forecast-201-validation.svg' | relative_url }}" alt="WAPE dos três modelos sob nove protocolos de validação temporal.">
+  <figcaption>O WAPE e o ranking variam com janela, gap, sobreposição e cadência de refit. A comparação controla série, modelos, horizonte e métrica.</figcaption>
+</figure>
+
+## 6. Refit: desempenho do modelo ou da política de atualização?
+
+Um modelo pode ser executado várias vezes sem ser reajustado. A distinção é
+relevante para sistemas nos quais o treino é caro, depende de aprovação ou
+ocorre em cadência diferente da geração de previsões.
+
+No protocolo de referência, a regressão é reajustada em toda origem. Em seguida,
+o mesmo ajuste é reutilizado por duas ou quatro origens. Calendário futuro
+continua disponível, mas os coeficientes não incorporam as observações surgidas
+depois do último *refit*.
+
+| Política | Seasonal naive | Média sazonal | Regressão |
+|---|---:|---:|---:|
+| Refit em toda origem | 5,34% | 5,30% | **4,63%** |
+| Refit a cada 2 origens | 5,34% | **5,30%** | 5,31% |
+| Refit a cada 4 origens | 5,34% | **5,30%** | 5,41% |
+
+A regressão deixa de apresentar o menor valor quando sua atualização é menos
+frequente. Sob *refit* a cada duas origens, sua diferença para a média sazonal é
+de apenas 0,01 ponto percentual — pequena demais para sustentar superioridade
+sem uma análise de variabilidade. A cada quatro origens, o WAPE chega a 5,41%.
+
+O seasonal naive e a média sazonal foram mantidos com atualização própria em
+cada origem; o congelamento foi aplicado à regressão para isolar sua política de
+treino. Em uma comparação de sistemas completos, todas as políticas precisariam
+ser especificadas de acordo com a operação.
+
+O resultado demonstra por que a cadência deve constar na documentação do
+experimento. Parte do ganho atribuído ao modelo pode ser, na realidade, ganho
+da atualização. Se duas soluções possuem políticas de *refit* diferentes, uma
+comparação justa deve reportar acurácia, custo computacional, latência,
+estabilidade e frequência de treinamento.
+
+## 7. Seleção sem reutilizar a avaliação
+
+Escolher uma janela depois de observar o WAPE de todos os protocolos usa o
+backtest como conjunto de seleção. Relatar o menor desses valores como
+estimativa imparcial de desempenho ignora que o menor valor foi selecionado
+entre várias alternativas.
+
+A validação aninhada introduz dois níveis. Para cada origem externa \(T_k\),
+folds internos anteriores a \(T_k\) selecionam:
+
+\[
+\widehat{W}_k
+=
+\arg\min_{W\in\{180,365,730\}}
+\frac{1}{J_k}
+\sum_{j=1}^{J_k}
+\operatorname{WAPE}_{k,j}(W)
+\]
+
+Depois, a regressão é reajustada na janela \(\widehat{W}_k\) e avaliada uma vez
+no fold externo. Os resultados externos não voltam para a seleção daquela
+origem. A estrutura aninhada separa escolha de configuração e estimação externa,
+reduzindo o viés associado à reutilização da mesma avaliação
+([Varma e Simon, 2006](https://doi.org/10.1186/1471-2105-7-91)).
+
+| Origem externa | Janela selecionada | WAPE externo |
+|---:|---:|---:|
+| 1.068 | 180 dias | 3,08% |
+| 1.124 | 180 dias | 3,27% |
+| 1.180 | 180 dias | 11,57% |
+| 1.236 | 365 dias | 4,11% |
+
+Os três primeiros folds selecionaram 180 dias. No terceiro, essa janela
+encontrou uma transição de regime e o WAPE externo atingiu 11,57%. O resultado
+não invalida a seleção interna: mostra que uma escolha baseada no passado pode
+falhar quando o futuro muda. Na última origem, os folds internos já continham
+mais evidência do novo regime e selecionaram 365 dias.
+
+A mediana das escolhas internas foi 180 dias, configuração congelada antes do
+teste final. Essa regra é simples e previamente especificada. Outra regra seria
+possível, como escolher a janela mais frequente ou refazer a seleção em cada
+origem operacional. O ponto metodológico é registrar a regra antes de consultar
+o bloco reservado.
+
+Validação aninhada não elimina mudança de regime nem garante que o
+hiperparâmetro escolhido continuará adequado. Sua função é separar o erro do
+procedimento de seleção do erro usado para avaliar o procedimento já
+selecionado.
+
+## 8. O teste final bloqueado
+
+Os 168 dias finais são divididos em seis origens não sobrepostas. A regressão
+usa janela de 180 dias, escolhida no desenvolvimento, e é reajustada em cada
+origem. Nenhum resultado desse bloco altera a especificação.
+
+| Modelo | MAE | WAPE | Viés |
+|---|---:|---:|---:|
+| Seasonal naive | 13,97 | 5,77% | -1,14% |
+| Média sazonal | 17,02 | 7,06% | 3,88% |
+| Regressão de calendário | **12,66** | **5,23%** | **-0,02%** |
+
+A regressão apresentou o menor erro e viés praticamente nulo. A redução relativa
+do WAPE em comparação ao seasonal naive foi de aproximadamente 9,3%. O ganho é
+menor que aquele observado para a janela de 365 dias no backtest de
+desenvolvimento e não deve ser interpretado como garantia de estabilidade.
+
+O teste final contém apenas seis horizontes. Ele fornece uma avaliação externa
+dos candidatos congelados, mas continua sendo uma amostra temporal limitada.
+Bloquear o período reduz sua reutilização durante a seleção; não elimina outras
+fontes de otimismo nem a incerteza associada ao regime que ocorreu nele.
+
+Depois da consulta, qualquer modificação orientada por esses resultados muda o
+status do bloco. Se a janela for alterada porque a média sazonal teve viés
+positivo, por exemplo, os 168 dias passam a integrar o desenvolvimento. Uma
+nova estimativa final exigiria dados posteriores ou avaliação prospectiva.
+
+## 9. O ranking como variável do experimento
+
+O seasonal naive apresentou o menor WAPE em dois dos nove protocolos de
+desenvolvimento. A regressão apresentou o menor valor em cinco. A média sazonal
+ocupou essa posição nos dois protocolos com *refit* menos frequente da
+regressão. Nenhum modelo foi invariavelmente superior.
+
+Uma medida descritiva de estabilidade pode ser definida como:
+
+\[
+S_m
+=
+\frac{1}{P}
+\sum_{p=1}^{P}
+\mathbb{1}\{\operatorname{rank}_{m,p}=1\}
+\]
+
+em que \(P\) é o número de protocolos e \(S_m\) é a proporção em que o modelo
+\(m\) ocupa a primeira posição. No conjunto avaliado, a regressão apresenta
+\(S=5/9\), o seasonal naive \(S=2/9\) e a média sazonal \(S=2/9\).
+
+Essa medida não constitui probabilidade de vitória em produção. Os protocolos
+não são uma amostra aleatória de cenários e diferem em mais do que dificuldade.
+Ela serve para revelar fragilidade: uma recomendação baseada apenas no melhor
+WAPE de uma configuração omite que o ranking se inverte sob condições
+operacionais plausíveis.
+
+Uma decisão de implantação deveria considerar ao menos três dimensões:
+desempenho no protocolo que representa a operação, estabilidade em análises de
+sensibilidade e resultado no teste bloqueado. O protocolo operacional tem
+prioridade; não se deve escolher retrospectivamente aquele que favorece o
+modelo preferido.
+
+## 10. O que pode e o que não pode ser concluído
+
+O experimento sustenta quatro conclusões restritas.
+
+Primeiro, a quantidade de histórico alterou substancialmente a regressão em um
+processo que continha mudanças de regime. Segundo, aumentar o gap reduziu a
+vantagem descritiva do candidato, mostrando que a antecedência operacional faz
+parte da dificuldade avaliada. Terceiro, folds sobrepostos alteraram as origens avaliadas e
+introduziram dependência, sem produzir uma relação monotônica com o erro.
+Quarto, reduzir a frequência de *refit* foi suficiente para inverter o ranking.
+
+Não se conclui que janelas deslizantes sejam geralmente superiores, que 180 ou
+365 dias sejam tamanhos recomendados para dados reais, nem que regressão de
+calendário seja o melhor modelo de demanda. A série é sintética, os eventos são
+controlados e existem apenas três previsores simples.
+
+Também não foi estimado um intervalo de confiança para a diferença entre os
+modelos. A dependência entre folds, sobretudo nos protocolos sobrepostos,
+exigiria um procedimento inferencial compatível. O objetivo aqui é estudar a
+sensibilidade do estimador de desempenho, não produzir uma declaração
+populacional sobre superioridade.
+
+O refit foi simplificado. Em sistemas reais, reprocessar features, retreinar,
+selecionar hiperparâmetros, calibrar intervalos e publicar previsões podem ter
+cadências distintas. A política completa precisa ser reconstruída no backtest.
+
+## 11. Implicações para projetos de forecast
+
+Um protocolo temporal deve ser tratado como parte versionada do produto
+analítico. Além do modelo e das features, a documentação precisa registrar:
+
+- origem e horizonte;
+- regra de formação da janela;
+- gap e sua justificativa;
+- passo entre origens;
+- grau de sobreposição;
+- cadência de refit;
+- elementos reajustados em cada fold;
+- nível interno e externo de seleção;
+- localização e governança do teste final.
+
+Esses parâmetros devem derivar do processo decisório. Se o planejamento é
+mensal, o passo entre origens pode ser mensal. Se a previsão é republicada
+semanalmente para um horizonte de quatro semanas, a sobreposição deve aparecer.
+Se dados levam sete dias para fechar, o gap precisa representar essa latência.
+Se o treinamento ocorre trimestralmente, um backtest com *refit* diário
+superestima o sistema disponível.
+
+Análises de sensibilidade continuam úteis, mas têm função diferente. Elas
+mostram quanto a conclusão depende de escolhas plausíveis. Não autorizam a
+seleção oportunista do protocolo que produz a narrativa desejada.
+
+## Conclusão
+
+O desenho de validação alterou tanto a magnitude do erro quanto o ranking dos
+modelos. A regressão de calendário apresentou o maior WAPE sob janela expansiva,
+o menor sob janela deslizante de 365 dias e deixou a primeira posição quando seu
+*refit* se tornou menos frequente. Gaps maiores reduziram sua vantagem, enquanto
+folds sobrepostos mudaram a composição e a dependência das avaliações.
+
+A validação aninhada selecionou uma janela de 180 dias para a regressão antes da
+abertura do teste final. Nesse bloco, ela registrou WAPE de 5,23%, valor menor
+que o seasonal naive, mas menos favorável que algumas estimativas do
+desenvolvimento. O bloco forneceu uma comparação externa sem reutilizar o
+período que orientou a seleção da janela.
+
+Em forecast, avaliar não significa apenas separar passado e futuro. Significa
+reconstruir uma política de uso: quanto histórico estará disponível, qual será
+a antecedência, quando o modelo será atualizado e quantas previsões coexistirão
+para as mesmas datas. O ranking é condicionado a essa política. Sem declará-la,
+sua utilidade operacional é limitada.
+
+## Caderno técnico
+
+O código, os testes e a reprodução integral estão disponíveis no
+[Laboratório Forecast 201]({{ page.laboratory | relative_url }}).
+
+## Referências
+
+- Tashman, L. J. (2000). [Out-of-sample tests of forecasting accuracy: an
+  analysis and review](https://doi.org/10.1016/S0169-2070(00)00065-0).
+  *International Journal of Forecasting*, 16(4), 437–450.
+- Bergmeir, C.; Hyndman, R. J.; Koo, B. (2018). [A note on the validity of
+  cross-validation for evaluating autoregressive time series
+  prediction](https://doi.org/10.1016/j.csda.2017.11.003).
+  *Computational Statistics & Data Analysis*, 120, 70–83.
+- Cerqueira, V.; Torgo, L.; Mozetič, I. (2020). [Evaluating time series
+  forecasting models: an empirical study on performance estimation
+  methods](https://doi.org/10.1007/s10994-020-05910-7).
+  *Machine Learning*, 109, 1997–2028.
+- Varma, S.; Simon, R. (2006). [Bias in error estimation when using
+  cross-validation for model selection](https://doi.org/10.1186/1471-2105-7-91).
+  *BMC Bioinformatics*, 7, 91.
+- Hyndman, R. J.; Athanasopoulos, G. (2021). [Forecasting: Principles and
+  Practice](https://otexts.com/fpp3/), 3ª ed. OTexts.

--- a/assets/images/forecast-201-validation.svg
+++ b/assets/images/forecast-201-validation.svg
@@ -1,0 +1,61 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1180" height="620" viewBox="0 0 1180 620">
+<rect width="100%" height="100%" fill="#f3eedf"/>
+<text x="90" y="35" font-family="Georgia,serif" font-size="24" fill="#22201d">WAPE estimado por protocolo de validação</text>
+<line x1="90" y1="480.0" x2="1100" y2="480.0" stroke="#d7cfbb"/>
+<text x="78" y="485.0" text-anchor="end" font-family="Arial" font-size="13" fill="#625d54">0%</text>
+<line x1="90" y1="397.6" x2="1100" y2="397.6" stroke="#d7cfbb"/>
+<text x="78" y="402.6" text-anchor="end" font-family="Arial" font-size="13" fill="#625d54">2%</text>
+<line x1="90" y1="315.3" x2="1100" y2="315.3" stroke="#d7cfbb"/>
+<text x="78" y="320.3" text-anchor="end" font-family="Arial" font-size="13" fill="#625d54">4%</text>
+<line x1="90" y1="232.9" x2="1100" y2="232.9" stroke="#d7cfbb"/>
+<text x="78" y="237.9" text-anchor="end" font-family="Arial" font-size="13" fill="#625d54">6%</text>
+<line x1="90" y1="150.6" x2="1100" y2="150.6" stroke="#d7cfbb"/>
+<text x="78" y="155.6" text-anchor="end" font-family="Arial" font-size="13" fill="#625d54">8%</text>
+<line x1="90" y1="68.2" x2="1100" y2="68.2" stroke="#d7cfbb"/>
+<text x="78" y="73.2" text-anchor="end" font-family="Arial" font-size="13" fill="#625d54">10%</text>
+<polyline points="90.0,259.9 216.2,259.9 342.5,259.9 468.8,247.4 595.0,238.5 721.2,230.9 847.5,253.2 973.8,259.9 1100.0,259.9" fill="none" stroke="#22201d" stroke-width="3"/>
+<circle cx="90.0" cy="259.9" r="4" fill="#22201d"/>
+<circle cx="216.2" cy="259.9" r="4" fill="#22201d"/>
+<circle cx="342.5" cy="259.9" r="4" fill="#22201d"/>
+<circle cx="468.8" cy="247.4" r="4" fill="#22201d"/>
+<circle cx="595.0" cy="238.5" r="4" fill="#22201d"/>
+<circle cx="721.2" cy="230.9" r="4" fill="#22201d"/>
+<circle cx="847.5" cy="253.2" r="4" fill="#22201d"/>
+<circle cx="973.8" cy="259.9" r="4" fill="#22201d"/>
+<circle cx="1100.0" cy="259.9" r="4" fill="#22201d"/>
+<polyline points="90.0,130.3 216.2,261.8 342.5,209.7 468.8,259.4 595.0,256.3 721.2,194.7 847.5,175.2 973.8,261.8 1100.0,261.8" fill="none" stroke="#b4492c" stroke-width="3"/>
+<circle cx="90.0" cy="130.3" r="4" fill="#b4492c"/>
+<circle cx="216.2" cy="261.8" r="4" fill="#b4492c"/>
+<circle cx="342.5" cy="209.7" r="4" fill="#b4492c"/>
+<circle cx="468.8" cy="259.4" r="4" fill="#b4492c"/>
+<circle cx="595.0" cy="256.3" r="4" fill="#b4492c"/>
+<circle cx="721.2" cy="194.7" r="4" fill="#b4492c"/>
+<circle cx="847.5" cy="175.2" r="4" fill="#b4492c"/>
+<circle cx="973.8" cy="261.8" r="4" fill="#b4492c"/>
+<circle cx="1100.0" cy="261.8" r="4" fill="#b4492c"/>
+<polyline points="90.0,113.9 216.2,289.3 342.5,259.2 468.8,277.9 595.0,261.2 721.2,257.6 847.5,278.8 973.8,261.2 1100.0,257.4" fill="none" stroke="#c59622" stroke-width="3"/>
+<circle cx="90.0" cy="113.9" r="4" fill="#c59622"/>
+<circle cx="216.2" cy="289.3" r="4" fill="#c59622"/>
+<circle cx="342.5" cy="259.2" r="4" fill="#c59622"/>
+<circle cx="468.8" cy="277.9" r="4" fill="#c59622"/>
+<circle cx="595.0" cy="261.2" r="4" fill="#c59622"/>
+<circle cx="721.2" cy="257.6" r="4" fill="#c59622"/>
+<circle cx="847.5" cy="278.8" r="4" fill="#c59622"/>
+<circle cx="973.8" cy="261.2" r="4" fill="#c59622"/>
+<circle cx="1100.0" cy="257.4" r="4" fill="#c59622"/>
+<text x="90.0" y="505" transform="rotate(35 90.0 505)" font-family="Arial" font-size="12" fill="#403c36">Expansiva</text>
+<text x="216.2" y="505" transform="rotate(35 216.2 505)" font-family="Arial" font-size="12" fill="#403c36">Janela 365d</text>
+<text x="342.5" y="505" transform="rotate(35 342.5 505)" font-family="Arial" font-size="12" fill="#403c36">Janela 180d</text>
+<text x="468.8" y="505" transform="rotate(35 468.8 505)" font-family="Arial" font-size="12" fill="#403c36">Gap 7d</text>
+<text x="595.0" y="505" transform="rotate(35 595.0 505)" font-family="Arial" font-size="12" fill="#403c36">Gap 14d</text>
+<text x="721.2" y="505" transform="rotate(35 721.2 505)" font-family="Arial" font-size="12" fill="#403c36">Sobrep. 50%</text>
+<text x="847.5" y="505" transform="rotate(35 847.5 505)" font-family="Arial" font-size="12" fill="#403c36">Sobrep. 75%</text>
+<text x="973.8" y="505" transform="rotate(35 973.8 505)" font-family="Arial" font-size="12" fill="#403c36">Refit a cada 2 origens</text>
+<text x="1100.0" y="505" transform="rotate(35 1100.0 505)" font-family="Arial" font-size="12" fill="#403c36">Refit a cada 4 origens</text>
+<line x1="90" y1="590" x2="118" y2="590" stroke="#22201d" stroke-width="4"/>
+<text x="126" y="595" font-family="Arial" font-size="14" fill="#22201d">Seasonal naive</text>
+<line x1="360" y1="590" x2="388" y2="590" stroke="#b4492c" stroke-width="4"/>
+<text x="396" y="595" font-family="Arial" font-size="14" fill="#22201d">Média sazonal</text>
+<line x1="630" y1="590" x2="658" y2="590" stroke="#c59622" stroke-width="4"/>
+<text x="666" y="595" font-family="Arial" font-size="14" fill="#22201d">Regressão de calendário</text>
+</svg>

--- a/laboratorio.md
+++ b/laboratorio.md
@@ -12,10 +12,19 @@ suficientes para reprodução e revisão.
 <article class="project-dossier">
   <span class="dossier-number">01</span>
   <p class="eyebrow">ATIVO · SÉRIES TEMPORAIS</p>
-  <h2><a href="{{ '/laboratorio/forecast-101/' | relative_url }}">Forecast 101: prever não é adivinhar</a></h2>
+  <h2><a href="{{ '/laboratorio/forecast-101/' | relative_url }}">Forecast 101: avaliação temporal, incerteza e decisão</a></h2>
   <p>Um laboratório reproduzível sobre baseline sazonal, validação temporal,
   métricas de erro, incerteza e decisão.</p>
   <a class="read-link" href="{{ '/laboratorio/forecast-101/' | relative_url }}">Abrir caderno técnico →</a>
+</article>
+
+<article class="project-dossier">
+  <span class="dossier-number">02</span>
+  <p class="eyebrow">ATIVO · VALIDAÇÃO TEMPORAL</p>
+  <h2><a href="{{ '/laboratorio/forecast-201/' | relative_url }}">Forecast 201: como a validação temporal altera a conclusão</a></h2>
+  <p>Um experimento controlado sobre janelas, gaps, sobreposição, refit,
+  validação aninhada e teste final bloqueado.</p>
+  <a class="read-link" href="{{ '/laboratorio/forecast-201/' | relative_url }}">Abrir caderno técnico →</a>
 </article>
 
 ## Critério de publicação

--- a/laboratorios/forecast-201/README.md
+++ b/laboratorios/forecast-201/README.md
@@ -1,0 +1,36 @@
+# Forecast 201 — validação temporal
+
+Laboratório reproduzível do artigo “Forecast 201: como a validação temporal
+altera a conclusão”.
+
+## O que demonstra
+
+- separação entre desenvolvimento e teste final bloqueado;
+- janelas expansiva e deslizantes;
+- gaps de 7 e 14 dias;
+- folds não sobrepostos e sobrepostos;
+- diferentes cadências de refit;
+- seleção de janela por validação temporal aninhada;
+- sensibilidade do WAPE e do ranking ao protocolo.
+
+## Executar
+
+```bash
+python3 forecast_201.py
+python3 -m unittest -v test_forecast_201.py
+```
+
+O laboratório usa somente a biblioteca padrão do Python 3.10 ou superior.
+
+O parecer de integridade que confronta manuscrito, código e resultados está em
+[`REVIEW.md`](REVIEW.md).
+
+## Convenções
+
+- origem é o primeiro índice ainda não utilizado no treinamento;
+- gap começa imediatamente após a origem;
+- horizonte é sempre de 28 dias;
+- o teste final contém 168 dias e não participa da seleção;
+- folds sobrepostos são tratados como medições dependentes;
+- erro é previsão menos observado;
+- resultados sintéticos demonstram método, não desempenho operacional.

--- a/laboratorios/forecast-201/REVIEW.md
+++ b/laboratorios/forecast-201/REVIEW.md
@@ -1,0 +1,47 @@
+# Parecer de integridade — Forecast 201
+
+## Escopo
+
+Revisão cruzada entre manuscrito, código, testes e saída reproduzida. O parecer
+verifica correspondência factual, alcance das conclusões, rastreabilidade das
+referências e distinção entre seleção, avaliação e interpretação.
+
+## Correções realizadas antes da publicação
+
+- explicitado que a validação aninhada seleciona a janela da regressão, não o
+  modelo entre os três candidatos;
+- reformulado o teste final como comparação externa de candidatos congelados;
+- corrigida a redução relativa do WAPE de 9,4% para 9,3%;
+- incorporado o gap à fórmula do WAPE por fold;
+- esclarecido que os protocolos formam análise de sensibilidade, não produto
+  cartesiano;
+- rebaixadas explicações mecanísticas sobre regimes a hipóteses compatíveis com
+  o desenho;
+- removidas declarações categóricas de superioridade em diferenças sem análise
+  de variabilidade;
+- adicionadas citações no corpo para avaliação fora da amostra, validação
+  temporal, dependência e viés de seleção.
+
+## Verificações
+
+- os valores das nove comparações coincidem com a execução;
+- os quatro resultados externos da validação aninhada coincidem com a execução;
+- a janela final de 180 dias corresponde à regra implementada;
+- MAE, WAPE e viés dos três candidatos no teste final coincidem com a execução;
+- as origens de desenvolvimento não alcançam o teste final;
+- os seis folds finais não se sobrepõem;
+- os cinco testes automatizados foram aprovados.
+
+## Ressalvas remanescentes
+
+- não há inferência para diferenciais de perda entre modelos;
+- folds sobrepostos são dependentes e não equivalem a replicações independentes;
+- o teste final contém somente seis origens;
+- a série e as mudanças de regime são sintéticas;
+- a política de refit foi simplificada;
+- o estudo estima sensibilidade do protocolo, não desempenho empresarial.
+
+## Parecer
+
+Publicável como experimento metodológico reproduzível. As conclusões devem
+permanecer restritas ao processo simulado e às configurações executadas.

--- a/laboratorios/forecast-201/forecast_201.py
+++ b/laboratorios/forecast-201/forecast_201.py
@@ -1,0 +1,426 @@
+"""Forecast 201: como o protocolo de validação altera a conclusão.
+
+Objetivo
+--------
+Comparar protocolos temporais mantendo dados, modelos, horizonte e métricas
+constantes. O laboratório mede o efeito de janela, gap, sobreposição e cadência
+de refit, executa seleção temporal aninhada e consulta um teste final bloqueado.
+
+Entradas
+--------
+Não há arquivos externos. A série diária sintética contém tendência,
+sazonalidade semanal e anual, dois regimes e eventos não fornecidos aos modelos.
+
+Processamento
+-------------
+1. Reserva os 168 dias finais antes de qualquer comparação.
+2. Executa backtests no desenvolvimento com horizonte de 28 dias.
+3. Compara seasonal naive, média sazonal e regressão de calendário.
+4. Varia uma dimensão do protocolo por vez.
+5. Seleciona a janela da regressão em folds internos e avalia folds externos.
+6. Reajusta a especificação escolhida e consulta uma única vez o teste final.
+
+Saídas
+------
+Tabelas no terminal e `assets/images/forecast-201-validation.svg`.
+
+Interpretação
+-------------
+Os resultados descrevem sensibilidade ao desenho de avaliação em uma simulação.
+Não estimam desempenho para uma empresa real nem tornam folds sobrepostos
+independentes.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+from dataclasses import dataclass
+from datetime import date, timedelta
+from pathlib import Path
+from statistics import mean, median
+
+
+SEED = 201
+N_OBSERVATIONS = 1460
+HORIZON = 28
+FINAL_TEST_DAYS = 168
+SEASONAL_LAG = 7
+OUTPUT = Path(__file__).resolve().parents[2] / "assets/images/forecast-201-validation.svg"
+
+
+@dataclass(frozen=True)
+class Protocol:
+    name: str
+    window: int | None
+    gap: int
+    step: int
+    refit_every: int = 1
+
+
+@dataclass(frozen=True)
+class Fold:
+    protocol: str
+    model: str
+    origin: int
+    mae: float
+    wape: float
+    bias: float
+
+
+def make_series() -> tuple[list[date], list[float]]:
+    """Gera demanda com mudanças que tornam a escolha de janela substantiva."""
+    rng = random.Random(SEED)
+    start = date(2022, 1, 3)
+    dates = [start + timedelta(days=i) for i in range(N_OBSERVATIONS)]
+    weekday = [8, 14, 10, 2, -5, -18, -11]
+    events = {220: 42, 411: -38, 705: 55, 990: -46, 1215: 61, 1392: 45}
+    values: list[float] = []
+
+    for i, current in enumerate(dates):
+        if i < 760:
+            level, slope, weekly_scale = 210.0, 0.055, 1.0
+        elif i < 1190:
+            level, slope, weekly_scale = 278.0, -0.018, 1.35
+        else:
+            level, slope, weekly_scale = 238.0, 0.082, 0.82
+        local_i = i if i < 760 else i - (760 if i < 1190 else 1190)
+        annual = 17 * math.sin(2 * math.pi * i / 365.25)
+        noise = rng.gauss(0, 11.5)
+        value = (
+            level
+            + slope * local_i
+            + weekly_scale * weekday[current.weekday()]
+            + annual
+            + events.get(i, 0)
+            + noise
+        )
+        values.append(max(value, 1.0))
+    return dates, values
+
+
+def calendar_features(current: date, reference: date) -> list[float]:
+    """Cria atributos conhecidos na origem: tendência, calendário e harmônicos."""
+    elapsed = (current - reference).days / 365.25
+    weekday = [1.0 if current.weekday() == day else 0.0 for day in range(1, 7)]
+    angle = 2 * math.pi * elapsed
+    return [1.0, elapsed, *weekday, math.sin(angle), math.cos(angle)]
+
+
+def solve_linear(rows: list[list[float]], target: list[float]) -> list[float]:
+    """Resolve mínimos quadrados com regularização diagonal numérica."""
+    width = len(rows[0])
+    matrix = [
+        [sum(row[i] * row[j] for row in rows) for j in range(width)]
+        for i in range(width)
+    ]
+    vector = [sum(row[i] * value for row, value in zip(rows, target)) for i in range(width)]
+    scale = max(matrix[i][i] for i in range(width))
+    for i in range(width):
+        matrix[i][i] += scale * 1e-9
+
+    for pivot in range(width):
+        best = max(range(pivot, width), key=lambda row: abs(matrix[row][pivot]))
+        matrix[pivot], matrix[best] = matrix[best], matrix[pivot]
+        vector[pivot], vector[best] = vector[best], vector[pivot]
+        divisor = matrix[pivot][pivot]
+        if abs(divisor) < 1e-12:
+            raise ValueError("Matriz singular.")
+        for column in range(pivot, width):
+            matrix[pivot][column] /= divisor
+        vector[pivot] /= divisor
+        for row in range(width):
+            if row == pivot:
+                continue
+            factor = matrix[row][pivot]
+            for column in range(pivot, width):
+                matrix[row][column] -= factor * matrix[pivot][column]
+            vector[row] -= factor * vector[pivot]
+    return vector
+
+
+def fit_calendar(
+    dates: list[date], values: list[float], start: int, end: int
+) -> tuple[list[float], date]:
+    """Ajusta a regressão exclusivamente em [start, end)."""
+    reference = dates[start]
+    rows = [calendar_features(dates[i], reference) for i in range(start, end)]
+    return solve_linear(rows, values[start:end]), reference
+
+
+def predict_calendar(
+    coefficients: list[float], reference: date, future: list[date]
+) -> list[float]:
+    return [
+        max(0.0, sum(x * beta for x, beta in zip(calendar_features(day, reference), coefficients)))
+        for day in future
+    ]
+
+
+def seasonal_naive(values: list[float], train_end: int, horizon: int) -> list[float]:
+    season = values[train_end - SEASONAL_LAG : train_end]
+    return [season[h % SEASONAL_LAG] for h in range(horizon)]
+
+
+def seasonal_mean(
+    dates: list[date], values: list[float], train_start: int, train_end: int, future: list[date]
+) -> list[float]:
+    buckets = {
+        weekday: [
+            values[i]
+            for i in range(train_start, train_end)
+            if dates[i].weekday() == weekday
+        ]
+        for weekday in range(7)
+    }
+    return [mean(buckets[day.weekday()]) for day in future]
+
+
+def metrics(actual: list[float], predicted: list[float]) -> tuple[float, float, float]:
+    errors = [p - y for p, y in zip(predicted, actual)]
+    absolute = [abs(error) for error in errors]
+    volume = sum(abs(value) for value in actual)
+    return mean(absolute), 100 * sum(absolute) / volume, 100 * sum(errors) / volume
+
+
+def origins_for(protocol: Protocol, development_end: int, folds: int = 10) -> list[int]:
+    """Retorna origens cujos testes terminam dentro do desenvolvimento."""
+    latest = development_end - protocol.gap - HORIZON
+    origins = [latest - protocol.step * offset for offset in reversed(range(folds))]
+    minimum = 420 if protocol.window is None else protocol.window
+    return [origin for origin in origins if origin >= minimum]
+
+
+def run_protocol(
+    dates: list[date],
+    values: list[float],
+    development_end: int,
+    protocol: Protocol,
+    folds: int = 10,
+) -> list[Fold]:
+    """Executa um protocolo sem permitir acesso ao teste final."""
+    results: list[Fold] = []
+    cached_fit: tuple[list[float], date] | None = None
+
+    for fold_number, origin in enumerate(origins_for(protocol, development_end, folds)):
+        train_start = 0 if protocol.window is None else origin - protocol.window
+        test_start = origin + protocol.gap
+        test_end = test_start + HORIZON
+        future_dates = dates[test_start:test_end]
+        actual = values[test_start:test_end]
+
+        predictions = {
+            "Seasonal naive": seasonal_naive(values, origin, HORIZON),
+            "Média sazonal": seasonal_mean(
+                dates, values, train_start, origin, future_dates
+            ),
+        }
+        if cached_fit is None or fold_number % protocol.refit_every == 0:
+            cached_fit = fit_calendar(dates, values, train_start, origin)
+        predictions["Regressão de calendário"] = predict_calendar(
+            cached_fit[0], cached_fit[1], future_dates
+        )
+
+        for model, forecast in predictions.items():
+            mae, wape, bias = metrics(actual, forecast)
+            results.append(Fold(protocol.name, model, origin, mae, wape, bias))
+    return results
+
+
+def summarize(results: list[Fold]) -> dict[tuple[str, str], dict[str, float]]:
+    grouped: dict[tuple[str, str], list[Fold]] = {}
+    for row in results:
+        grouped.setdefault((row.protocol, row.model), []).append(row)
+    return {
+        key: {
+            "MAE": mean(row.mae for row in rows),
+            "WAPE": mean(row.wape for row in rows),
+            "MEDIAN_WAPE": median(row.wape for row in rows),
+            "BIAS": mean(row.bias for row in rows),
+            "FOLDS": float(len(rows)),
+        }
+        for key, rows in grouped.items()
+    }
+
+
+def protocol_grid() -> list[Protocol]:
+    """Varia uma dimensão por vez em torno do protocolo de referência."""
+    return [
+        Protocol("Expansiva", None, 0, 28),
+        Protocol("Deslizante 365d", 365, 0, 28),
+        Protocol("Deslizante 180d", 180, 0, 28),
+        Protocol("Gap 7d", 365, 7, 28),
+        Protocol("Gap 14d", 365, 14, 28),
+        Protocol("Sobreposição 50%", 365, 0, 14),
+        Protocol("Sobreposição 75%", 365, 0, 7),
+        Protocol("Refit a cada 2 origens", 365, 0, 28, 2),
+        Protocol("Refit a cada 4 origens", 365, 0, 28, 4),
+    ]
+
+
+def winner_by_protocol(summary: dict[tuple[str, str], dict[str, float]]) -> dict[str, str]:
+    protocols = sorted({key[0] for key in summary})
+    return {
+        protocol: min(
+            (key for key in summary if key[0] == protocol),
+            key=lambda key: summary[key]["WAPE"],
+        )[1]
+        for protocol in protocols
+    }
+
+
+def nested_validation(
+    dates: list[date], values: list[float], development_end: int
+) -> tuple[list[dict[str, float | int]], dict[int, int]]:
+    """Seleciona a janela em folds internos e avalia origens externas."""
+    windows = [180, 365, 730]
+    outer_origins = list(range(development_end - 4 * 56, development_end, 56))
+    records: list[dict[str, float | int]] = []
+    selected: dict[int, int] = {}
+
+    for outer_origin in outer_origins:
+        inner_scores: dict[int, float] = {}
+        for window in windows:
+            protocol = Protocol(f"inner-{window}", window, 0, 28)
+            inner = run_protocol(dates, values, outer_origin, protocol, folds=4)
+            candidate = [row.wape for row in inner if row.model == "Regressão de calendário"]
+            inner_scores[window] = mean(candidate)
+        best_window = min(inner_scores, key=inner_scores.get)
+        selected[outer_origin] = best_window
+
+        train_start = outer_origin - best_window
+        coefficients, reference = fit_calendar(dates, values, train_start, outer_origin)
+        future = dates[outer_origin : outer_origin + HORIZON]
+        forecast = predict_calendar(coefficients, reference, future)
+        mae, wape, bias = metrics(values[outer_origin : outer_origin + HORIZON], forecast)
+        records.append(
+            {
+                "origin": outer_origin,
+                "window": best_window,
+                "mae": mae,
+                "wape": wape,
+                "bias": bias,
+            }
+        )
+    return records, selected
+
+
+def locked_final_test(
+    dates: list[date],
+    values: list[float],
+    development_end: int,
+    window: int,
+) -> dict[str, dict[str, float]]:
+    """Avalia origens não sobrepostas no teste final, após congelar a janela."""
+    rows: dict[str, list[tuple[float, float, float]]] = {
+        "Seasonal naive": [],
+        "Média sazonal": [],
+        "Regressão de calendário": [],
+    }
+    for origin in range(development_end, len(values) - HORIZON + 1, HORIZON):
+        train_start = max(0, origin - window)
+        future = dates[origin : origin + HORIZON]
+        actual = values[origin : origin + HORIZON]
+        coefficients, reference = fit_calendar(dates, values, train_start, origin)
+        forecasts = {
+            "Seasonal naive": seasonal_naive(values, origin, HORIZON),
+            "Média sazonal": seasonal_mean(dates, values, train_start, origin, future),
+            "Regressão de calendário": predict_calendar(coefficients, reference, future),
+        }
+        for model, forecast in forecasts.items():
+            rows[model].append(metrics(actual, forecast))
+    return {
+        model: {
+            "MAE": mean(item[0] for item in scores),
+            "WAPE": mean(item[1] for item in scores),
+            "BIAS": mean(item[2] for item in scores),
+            "FOLDS": float(len(scores)),
+        }
+        for model, scores in rows.items()
+    }
+
+
+def svg_chart(summary: dict[tuple[str, str], dict[str, float]]) -> None:
+    """Cria gráfico vetorial da sensibilidade do WAPE ao protocolo."""
+    protocols = [protocol.name for protocol in protocol_grid()]
+    models = ["Seasonal naive", "Média sazonal", "Regressão de calendário"]
+    colors = {"Seasonal naive": "#22201d", "Média sazonal": "#b4492c", "Regressão de calendário": "#c59622"}
+    width, height = 1180, 620
+    left, top, plot_width, plot_height = 90, 70, 1010, 410
+    max_value = max(summary[(p, m)]["WAPE"] for p in protocols for m in models) * 1.12
+
+    def x(index: int) -> float:
+        return left + index * plot_width / (len(protocols) - 1)
+
+    def y(value: float) -> float:
+        return top + plot_height * (1 - value / max_value)
+
+    elements = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" viewBox="0 0 {width} {height}">',
+        '<rect width="100%" height="100%" fill="#f3eedf"/>',
+        '<text x="90" y="35" font-family="Georgia,serif" font-size="24" fill="#22201d">WAPE estimado por protocolo de validação</text>',
+    ]
+    for tick in range(0, math.ceil(max_value) + 1, 2):
+        yy = y(tick)
+        elements.append(f'<line x1="{left}" y1="{yy:.1f}" x2="{left+plot_width}" y2="{yy:.1f}" stroke="#d7cfbb"/>')
+        elements.append(f'<text x="{left-12}" y="{yy+5:.1f}" text-anchor="end" font-family="Arial" font-size="13" fill="#625d54">{tick}%</text>')
+    for model in models:
+        points = " ".join(f"{x(i):.1f},{y(summary[(p, model)]['WAPE']):.1f}" for i, p in enumerate(protocols))
+        elements.append(f'<polyline points="{points}" fill="none" stroke="{colors[model]}" stroke-width="3"/>')
+        for i, protocol in enumerate(protocols):
+            elements.append(f'<circle cx="{x(i):.1f}" cy="{y(summary[(protocol, model)]["WAPE"]):.1f}" r="4" fill="{colors[model]}"/>')
+    for i, protocol in enumerate(protocols):
+        label = protocol.replace("Deslizante ", "Janela ").replace("Sobreposição ", "Sobrep. ")
+        elements.append(f'<text x="{x(i):.1f}" y="505" transform="rotate(35 {x(i):.1f} 505)" font-family="Arial" font-size="12" fill="#403c36">{label}</text>')
+    for i, model in enumerate(models):
+        xx = 90 + i * 270
+        elements.append(f'<line x1="{xx}" y1="590" x2="{xx+28}" y2="590" stroke="{colors[model]}" stroke-width="4"/>')
+        elements.append(f'<text x="{xx+36}" y="595" font-family="Arial" font-size="14" fill="#22201d">{model}</text>')
+    elements.append("</svg>")
+    OUTPUT.write_text("\n".join(elements), encoding="utf-8")
+
+
+def main() -> None:
+    dates, values = make_series()
+    development_end = len(values) - FINAL_TEST_DAYS
+    all_results = [
+        row
+        for protocol in protocol_grid()
+        for row in run_protocol(dates, values, development_end, protocol)
+    ]
+    summary = summarize(all_results)
+    winners = winner_by_protocol(summary)
+    nested, selected = nested_validation(dates, values, development_end)
+    final_window = int(median(selected.values()))
+    final = locked_final_test(dates, values, development_end, final_window)
+    svg_chart(summary)
+
+    print(f"Forecast 201 | desenvolvimento={development_end} dias | teste final={FINAL_TEST_DAYS} dias")
+    print(f"Horizonte={HORIZON} | série sintética | seed={SEED}\n")
+    print("WAPE médio por protocolo")
+    print(f"{'Protocolo':28} {'SNaive':>9} {'Média':>9} {'Regressão':>10}  Vencedor")
+    for protocol in protocol_grid():
+        print(
+            f"{protocol.name:28} "
+            f"{summary[(protocol.name, 'Seasonal naive')]['WAPE']:8.2f}% "
+            f"{summary[(protocol.name, 'Média sazonal')]['WAPE']:8.2f}% "
+            f"{summary[(protocol.name, 'Regressão de calendário')]['WAPE']:9.2f}%  "
+            f"{winners[protocol.name]}"
+        )
+    print("\nValidação aninhada da janela da regressão")
+    for row in nested:
+        print(
+            f"origem={int(row['origin']):4d} janela={int(row['window']):3d} "
+            f"WAPE externo={row['wape']:.2f}%"
+        )
+    print(f"Janela congelada para o teste final: {final_window} dias\n")
+    print("Teste final bloqueado")
+    for model, values_ in final.items():
+        print(
+            f"{model:26} MAE={values_['MAE']:.2f} "
+            f"WAPE={values_['WAPE']:.2f}% viés={values_['BIAS']:.2f}%"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/laboratorios/forecast-201/index.md
+++ b/laboratorios/forecast-201/index.md
@@ -1,0 +1,88 @@
+---
+layout: page
+title: "Forecast 201"
+description: "Caderno técnico reproduzível sobre janelas, gaps, sobreposição, refit, validação aninhada e teste final."
+permalink: /laboratorio/forecast-201/
+---
+
+<p class="lab-status"><span>LAB 02 · V1</span><span>EXECUTADO · TESTADO</span></p>
+
+## Pergunta
+
+Mantidos os dados, os modelos, o horizonte e as métricas, em que medida o
+protocolo de validação temporal altera a estimativa de desempenho e o ranking?
+
+## Desenho
+
+| Elemento | Definição |
+|---|---|
+| Série | sintética, diária, 1.460 observações, semente 201 |
+| Desenvolvimento | 1.292 dias |
+| Teste final | 168 dias bloqueados, seis origens não sobrepostas |
+| Horizonte | 28 dias |
+| Modelos | seasonal naive, média sazonal e regressão de calendário |
+| Janelas | expansiva, 365 dias e 180 dias |
+| Gaps | 0, 7 e 14 dias |
+| Passos | 28, 14 e 7 dias |
+| Refit | toda origem, a cada 2 ou a cada 4 origens |
+| Seleção | validação temporal aninhada de 180, 365 ou 730 dias |
+| Métricas | MAE, WAPE e viés |
+
+## Sensibilidade no desenvolvimento
+
+| Protocolo | Seasonal naive | Média sazonal | Regressão | Vencedor |
+|---|---:|---:|---:|---|
+| Expansiva | 5,34% | 8,49% | 8,89% | Seasonal naive |
+| Deslizante 365d | 5,34% | 5,30% | 4,63% | Regressão |
+| Deslizante 180d | 5,34% | 6,56% | 5,36% | Seasonal naive |
+| Gap 7d | 5,65% | 5,36% | 4,91% | Regressão |
+| Gap 14d | 5,86% | 5,43% | 5,31% | Regressão |
+| Sobreposição 50% | 6,05% | 6,93% | 5,40% | Regressão |
+| Sobreposição 75% | 5,51% | 7,40% | 4,89% | Regressão |
+| Refit a cada 2 origens | 5,34% | 5,30% | 5,31% | Média sazonal |
+| Refit a cada 4 origens | 5,34% | 5,30% | 5,41% | Média sazonal |
+
+<figure class="article-figure">
+  <img src="{{ '/assets/images/forecast-201-validation.svg' | relative_url }}" alt="Sensibilidade do WAPE dos modelos aos protocolos temporais.">
+  <figcaption>O protocolo altera o erro estimado e, em quatro configurações, o modelo com menor WAPE no desenho de referência.</figcaption>
+</figure>
+
+## Validação aninhada e teste final
+
+A janela foi selecionada apenas em folds internos. A mediana das quatro
+seleções externas foi 180 dias, configuração congelada antes da abertura do
+teste final.
+
+| Modelo | MAE final | WAPE final | Viés final |
+|---|---:|---:|---:|
+| Seasonal naive | 13,97 | 5,77% | -1,14% |
+| Média sazonal | 17,02 | 7,06% | 3,88% |
+| Regressão de calendário | **12,66** | **5,23%** | **-0,02%** |
+
+## Interpretação
+
+A regressão apresentou o menor WAPE no teste final, mas não foi invariavelmente
+superior no desenvolvimento. Janela, gap e refit representam políticas de uso, e não
+detalhes neutros de implementação. Folds sobrepostos aumentam a cobertura de
+origens, mas não geram evidência independente na mesma proporção.
+
+## Reprodução
+
+- [`forecast_201.py`](https://github.com/betinaschilling/betinaschilling.github.io/blob/master/laboratorios/forecast-201/forecast_201.py)
+- [`test_forecast_201.py`](https://github.com/betinaschilling/betinaschilling.github.io/blob/master/laboratorios/forecast-201/test_forecast_201.py)
+- [Parecer de integridade](https://github.com/betinaschilling/betinaschilling.github.io/blob/master/laboratorios/forecast-201/REVIEW.md)
+- [README técnico](https://github.com/betinaschilling/betinaschilling.github.io/tree/master/laboratorios/forecast-201)
+
+```bash
+cd laboratorios/forecast-201
+python3 forecast_201.py
+python3 -m unittest -v test_forecast_201.py
+```
+
+## Limitações
+
+Os resultados são sintéticos. A comparação não estima intervalos para
+diferenças entre modelos e não representa hierarquias, demanda intermitente ou
+custos de produção. A política de refit foi simplificada.
+
+[Ler o artigo público →]({% post_url 2026-07-28-forecast-201-validacao-temporal %})

--- a/laboratorios/forecast-201/requirements.txt
+++ b/laboratorios/forecast-201/requirements.txt
@@ -1,0 +1,1 @@
+# O laboratório usa somente a biblioteca padrão do Python 3.10 ou superior.

--- a/laboratorios/forecast-201/test_forecast_201.py
+++ b/laboratorios/forecast-201/test_forecast_201.py
@@ -1,0 +1,59 @@
+"""Testes de segurança metodológica do Forecast 201."""
+
+import unittest
+
+import forecast_201 as study
+
+
+class Forecast201Tests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.dates, cls.values = study.make_series()
+        cls.development_end = len(cls.values) - study.FINAL_TEST_DAYS
+
+    def test_development_never_reaches_locked_test(self) -> None:
+        for protocol in study.protocol_grid():
+            for origin in study.origins_for(protocol, self.development_end):
+                self.assertLessEqual(
+                    origin + protocol.gap + study.HORIZON,
+                    self.development_end,
+                )
+
+    def test_gap_changes_test_start_not_training_end(self) -> None:
+        origin = 1000
+        window = 365
+        no_gap = study.Protocol("sem gap", window, 0, 28)
+        gap = study.Protocol("gap", window, 14, 28)
+        self.assertEqual(origin - no_gap.window, origin - gap.window)
+        self.assertEqual(origin + gap.gap, origin + no_gap.gap + 14)
+        self.assertEqual(
+            origin + gap.gap + study.HORIZON,
+            origin + no_gap.gap + study.HORIZON + 14,
+        )
+
+    def test_overlapping_protocol_has_more_dependent_folds(self) -> None:
+        non_overlap = study.Protocol("não sobreposto", 365, 0, 28)
+        overlap = study.Protocol("sobreposto", 365, 0, 7)
+        non_origins = study.origins_for(non_overlap, self.development_end)
+        overlap_origins = study.origins_for(overlap, self.development_end)
+        self.assertEqual(non_origins[1] - non_origins[0], study.HORIZON)
+        self.assertLess(overlap_origins[1] - overlap_origins[0], study.HORIZON)
+
+    def test_nested_selection_uses_only_pre_outer_data(self) -> None:
+        records, selected = study.nested_validation(
+            self.dates, self.values, self.development_end
+        )
+        self.assertEqual(len(records), len(selected))
+        self.assertTrue(all(origin < self.development_end for origin in selected))
+        self.assertTrue(all(window in {180, 365, 730} for window in selected.values()))
+
+    def test_final_test_has_six_non_overlapping_folds(self) -> None:
+        final = study.locked_final_test(
+            self.dates, self.values, self.development_end, 365
+        )
+        self.assertEqual(final["Regressão de calendário"]["FOLDS"], 6.0)
+        self.assertEqual(set(final), {"Seasonal naive", "Média sazonal", "Regressão de calendário"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Entrega

- publica o artigo **Forecast 201: como a validação temporal altera a conclusão**;
- adiciona laboratório reproduzível com janela expansiva e deslizante, gaps, folds sobrepostos e cadência de refit;
- implementa seleção de janela por validação temporal aninhada e teste final bloqueado;
- adiciona gráfico vetorial, página do laboratório, testes e parecer de integridade;
- inclui o novo caderno no índice de laboratórios.

## Evidências principais

- a regressão varia de 8,89% de WAPE na janela expansiva para 4,63% na janela de 365 dias;
- gaps maiores reduzem sua vantagem;
- refits menos frequentes alteram a primeira posição;
- no teste final bloqueado, a regressão com janela de 180 dias registra WAPE de 5,23%.

## Validação

- `python3 forecast_201.py` executado integralmente;
- cinco testes metodológicos aprovados;
- fórmulas, métricas e manuscrito confrontados por revisão de integridade;
- `git diff --check` aprovado;
- SCSS compilado com Sass.

A comparação está um commit à frente de `master`, sem divergência, e contém somente o Forecast 201 e sua entrada no laboratório.